### PR TITLE
Try to polyfill Element.prototype.closest only when in a browser

### DIFF
--- a/jsoneditor-widget.js
+++ b/jsoneditor-widget.js
@@ -21,7 +21,7 @@ var Widget = require("$:/core/modules/widgets/widget.js").widget;
  * Element.closest() polyfill
  * https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Polyfill
  */
-if (!Element.prototype.closest) {
+if ($tw.browser && !Element.prototype.closest) {
 	if (!Element.prototype.matches) {
 		Element.prototype.matches = Element.prototype.msMatchesSelector || Element.prototype.webkitMatchesSelector;
 	}


### PR DESCRIPTION
I had the same issue as #2 (even after installing 0.0.6) and this at least makes the error go away for me. I'm not sure if this will break anything during server-side rendering.

The root of the issue, as I understood it, is that `jsoneditor-widget.js` references a class, [`Element`](https://developer.mozilla.org/en-US/docs/Web/API/Element), that's only present in a browser environment, even when the server is trying to render a page.

The full stacktrace can be seen by editing the plugin file and inserting `Error.stackTraceLimit = Infinity;` at the appropriate place in the text of `"$:/plugins/joshuafontany/jsoneditor/jsoneditor-widget.js"`, or invoking node with `--stack-trace-limit=10000`.

```
Error executing boot module $:/plugins/joshuafontany/jsoneditor/jsoneditor-widget.js: {}                                 
                                                                                                                         
$:/plugins/joshuafontany/jsoneditor/jsoneditor-widget.js:25                                                              
if (!Element.prototype.closest) {                                                                                        
^                                                                                                                        
                                                                                                                         
ReferenceError: Element is not defined                                                                                   
    at $:/plugins/joshuafontany/jsoneditor/jsoneditor-widget.js:25:1                                                     
    at $:/plugins/joshuafontany/jsoneditor/jsoneditor-widget.js:510:3                                                    
    at Script.runInContext (vm.js:127:20)
    at Script.runInNewContext (vm.js:133:17)
    at Object.runInNewContext (vm.js:299:38)
    at Object.$tw.utils.evalSandboxed (/usr/local/lib/node_modules/tiddlywiki/boot/boot.js:518:5)
    at Object.$tw.modules.execute (/usr/local/lib/node_modules/tiddlywiki/boot/boot.js:794:15)
    at /usr/local/lib/node_modules/tiddlywiki/boot/boot.js:834:30
    at Object.$tw.utils.each (/usr/local/lib/node_modules/tiddlywiki/boot/boot.js:135:12)
    at Object.$tw.modules.forEachModuleOfType (/usr/local/lib/node_modules/tiddlywiki/boot/boot.js:833:12)
    at Object.$tw.modules.applyMethods (/usr/local/lib/node_modules/tiddlywiki/boot/boot.js:857:14)
    at Widget.initialise ($:/core/modules/widgets/widget.js:52:48)
    at new Widget ($:/core/modules/widgets/widget.js:25:7)
    at $tw.Wiki.exports.makeWidget ($:/plugins/joshuafontany/jsonmangler/patchSource/core/modules/wiki.js:967:9)
    at $tw.Wiki.exports.renderTiddler ($:/plugins/joshuafontany/jsonmangler/patchSource/core/modules/wiki.js:1062:21)
    at Object.exports.handler ($:/core/modules/server/routes/get-index.js:26:24)
    at Server.requestHandler ($:/core/modules/server/server.js:205:9)
    at Server.emit (events.js:210:5)
    at parserOnIncoming (_http_server.js:742:12)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:111:17)
```

`at Object.$tw.modules.applyMethods ...` is the Widget class initializing and registering all the widget classes in the wiki.